### PR TITLE
Add optional callback function property "ready" for dynamic component…

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ export default {
     templateProps: {
       type: Object,
       default: () => ({}),
-    },
+	},
+	ready: Function,
   },
   render() {
     if (this.template) {
@@ -109,6 +110,9 @@ export default {
         computed: passthrough.computed,
         components: passthrough.components,
         provide: provide,
+		  mounted: () => {
+			  if (this.ready) this.ready()
+		  },
       };
       // debugger;
 


### PR DESCRIPTION
I'm using this component to render Vue components within HTML that is uses RevealJS to create a slideshow out of it. Unfortunately, RevealJS can only be initialized after the component has rendered into the DOM, and there's no event to hook into for that (at least that I could find).

So, this adds a prop called `ready`, which takes a callback function. When the dynamic component's loaded lifecycle event occurs, this callback function is fired, allowing the parent control to interact with the rendered DOM.

(I tried to make this an event first, but couldn't quite figure that one out.)